### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
         - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
         - '{{ ansible_distribution }}.yml'
         - '{{ ansible_os_family }}.yml'
-      skip: true
+      errors: ignore
       paths:
         - '{{ role_path }}/vars'
 


### PR DESCRIPTION
I get the following deprecation notice when running role:

```
[DEPRECATION WARNING]: Use errors="ignore" instead of skip. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

I think this fixes it