### PR TITLE
Handle new syntex for `includedir` statement

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
   become_user: root
   lineinfile:
     dest: '{{ sudoers_cfg_file }}'
-    regexp: '^#includedir\s+{{ sudoers_dropin_dir }}'
+    regexp: '^[#|@]includedir\s+{{ sudoers_dropin_dir }}'
     line: '#includedir {{ sudoers_dropin_dir }}'
 
 - name: ensure sudoreplay directory exists


### PR DESCRIPTION
On newer sudo versions the default inclusion statement is `@includedir` instead of `#includedir`. After running the role the directory gets included a second time:

```
@includedir /etc/sudoers.d
```

For compatibility reasons I didn't change the `line` value so on newer installations the `@includedir` will be replaced by the old syntax.

Reference:

> It is possible to include other sudoers files from within the -->

https://www.sudo.ws/docs/man/sudoers.man/#Including_other_files_from_within_sudoers

fixes #9