### PR TITLE
fix: add /etc/shadow permissions fix for BuildKit PAM error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,17 @@
     - /etc/pam.d/system-auth
     - /etc/pam.d/password-auth
 
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+- name: Fix /etc/shadow permissions for BuildKit containers (RHEL 9+)
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - sudoers_shadow_fix | default(false)
+  become: true
+  become_user: root
+  ansible.builtin.file:
+    path: /etc/shadow
+    mode: '0640'
+
 - name: Ensure sudoers dropin directory {{ sudoers_dropin_dir }} exists
   become: true
   become_user: root

--- a/vars/RedHat-10.yml
+++ b/vars/RedHat-10.yml
@@ -1,3 +1,5 @@
 ---
 sudoers_pam_sss_fix: true
 sudoers_nsswitch_sss_fix: true
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+sudoers_shadow_fix: true

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,3 +1,5 @@
 ---
 sudoers_pam_sss_fix: true
 sudoers_nsswitch_sss_fix: true
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+sudoers_shadow_fix: true

--- a/vars/Rocky-10.yml
+++ b/vars/Rocky-10.yml
@@ -1,3 +1,5 @@
 ---
 sudoers_pam_sss_fix: true
 sudoers_nsswitch_sss_fix: true
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+sudoers_shadow_fix: true

--- a/vars/Rocky-9.yml
+++ b/vars/Rocky-9.yml
@@ -1,3 +1,5 @@
 ---
 sudoers_pam_sss_fix: true
 sudoers_nsswitch_sss_fix: true
+# Fix for BuildKit PAM error: https://github.com/docker/build-push-action/issues/1302
+sudoers_shadow_fix: true


### PR DESCRIPTION
## Summary
- Add `/etc/shadow` permissions fix (mode 640) for BuildKit containers on RHEL 9+
- BuildKit containers can have `/etc/shadow` with mode 000, causing PAM authentication to fail
- This fixes the "sudo: PAM account management error: Authentication service cannot retrieve authentication info" error

## Root Cause
BuildKit's container execution environment can result in `/etc/shadow` having mode 000 (not readable even by root), which causes PAM to fail when validating account information.

## Test plan
- [x] Tested locally with Dagger on Rocky Linux 9, Rocky Linux 10, UBI 9
- [ ] CI should pass on all EL platforms after this fix

## References
- https://github.com/docker/build-push-action/issues/1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)